### PR TITLE
custom contest ui fixed

### DIFF
--- a/client/src/app/contest_reminders/page.js
+++ b/client/src/app/contest_reminders/page.js
@@ -1,27 +1,32 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import IUPCSection from "@/components/iupc-section"
 import ContestList from "@/components/contest-list"
 import CustomContestDisplay from "@/components/custom-contest-display"
+import IUPCSection from "@/components/iupc-section"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export default function Page() {
     return (
         <div className="min-h-screen bg-white dark:bg-zinc-900">
             <div className="container mx-auto px-4 py-8 space-y-10">
-                <CustomContestDisplay />
-                <Tabs defaultValue="iupc" className="w-full">
+                <Tabs defaultValue="mcc" className="w-full">
                     <div className="flex justify-center mb-8">
-                        <TabsList className="grid w-full max-w-md grid-cols-2 p-1 rounded-xl bg-zinc-100 dark:bg-zinc-800">
+                        <TabsList className="grid w-full max-w-lg grid-cols-3 p-1 rounded-xl bg-zinc-100 dark:bg-zinc-800">
                             <TabsTrigger
-                                value="iupc"
-                                className="rounded-lg px-8 py-2.5 data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-900 data-[state=active]:text-red-600 data-[state=active]:shadow-sm transition-all"
+                                value="mcc"
+                                className="rounded-lg px-4 py-2.5 data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-900 data-[state=active]:text-red-600 data-[state=active]:shadow-sm transition-all"
                             >
-                                IUPC
+                                MCC
                             </TabsTrigger>
                             <TabsTrigger
                                 value="general"
-                                className="rounded-lg px-8 py-2.5 data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-900 data-[state=active]:text-red-600 data-[state=active]:shadow-sm transition-all"
+                                className="rounded-lg px-4 py-2.5 data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-900 data-[state=active]:text-red-600 data-[state=active]:shadow-sm transition-all"
                             >
                                 General
+                            </TabsTrigger>
+                            <TabsTrigger
+                                value="iupc"
+                                className="rounded-lg px-4 py-2.5 data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-900 data-[state=active]:text-red-600 data-[state=active]:shadow-sm transition-all"
+                            >
+                                IUPC/ICPC
                             </TabsTrigger>
                         </TabsList>
                     </div>
@@ -32,6 +37,10 @@ export default function Page() {
 
                     <TabsContent value="general" className="space-y-8 focus-visible:outline-none focus-visible:ring-0">
                         <ContestList />
+                    </TabsContent>
+
+                    <TabsContent value="mcc" className="space-y-8 focus-visible:outline-none focus-visible:ring-0">
+                        <CustomContestDisplay />
                     </TabsContent>
                 </Tabs>
             </div>

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -281,6 +281,68 @@
   }
 }
 
+@keyframes slide-in-from-top {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-out-to-top {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-in {
+  animation: slide-in-from-top 0.3s ease-out;
+}
+
+.animate-out {
+  animation: slide-out-to-top 0.3s ease-in;
+}
+
+.animate-fade-in {
+  animation: fade-in 0.2s ease-out;
+}
+
+.animate-scale-in {
+  animation: scale-in 0.2s ease-out;
+}
+
 .alumni-card-float {
   animation: float 6s ease-in-out infinite;
 }

--- a/client/src/components/CustomContestManager.jsx
+++ b/client/src/components/CustomContestManager.jsx
@@ -1,126 +1,601 @@
 "use client"
-import { useActionState, useState, useTransition } from 'react'
-import { createCustomContestAction, updateCustomContestAction, deleteCustomContestAction } from '@/lib/action'
-import { useFormState } from 'react-dom'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { createCustomContestAction, deleteCustomContestAction, updateCustomContestAction } from '@/lib/action'
+import { CheckCircle, Edit3, Loader2, Plus, RefreshCw, Save, Trash2, X } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useActionState, useEffect, useState, useTransition } from 'react'
 
 export default function CustomContestManager({ initialContests }){
+  const router = useRouter()
   const [contests, setContests] = useState(initialContests || [])
   const [editing, setEditing] = useState(null)
   const [isPending, startTransition] = useTransition()
   const [deletedIds, setDeletedIds] = useState(new Set())
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [createLoading, setCreateLoading] = useState(false)
+  const [updateLoading, setUpdateLoading] = useState(false)
+  const [deleteLoading, setDeleteLoading] = useState(null)
+  const [showSuccess, setShowSuccess] = useState(null)
+  const [createFormRef, setCreateFormRef] = useState(null)
+  const [previewEndTime, setPreviewEndTime] = useState('')
 
-    const [createState, createAction] = useActionState(createCustomContestAction, { })
-    const [updateState, updateAction] = useActionState(updateCustomContestAction, { })
-    const [deleteState, deleteAction] = useActionState(deleteCustomContestAction, { })
+  const [createState, createAction] = useActionState(createCustomContestAction, { })
+  const [updateState, updateAction] = useActionState(updateCustomContestAction, { })
+  const [deleteState, deleteAction] = useActionState(deleteCustomContestAction, { })
+
+  // Calculate end time based on start time and duration
+  const calculateEndTime = (startTime, durationHours) => {
+    if (!startTime || !durationHours) return ''
+    
+    console.log('Calculating end time:')
+    console.log('Start time input:', startTime)
+    console.log('Duration hours:', durationHours)
+    
+    // datetime-local gives us a string like "2024-12-25T14:30"
+    // We need to parse this as local time, not UTC
+    // The string format is YYYY-MM-DDTHH:mm
+    const [datePart, timePart] = startTime.split('T')
+    const [year, month, day] = datePart.split('-').map(Number)
+    const [hour, minute] = timePart.split(':').map(Number)
+    
+    // Create date object with explicit local timezone
+    const start = new Date(year, month - 1, day, hour, minute) // month is 0-indexed
+    console.log('Parsed start date (local):', start.toLocaleString())
+    
+    const durationMs = parseFloat(durationHours) * 60 * 60 * 1000
+    console.log('Duration in ms:', durationMs)
+    
+    const end = new Date(start.getTime() + durationMs)
+    console.log('Calculated end date (local):', end.toLocaleString())
+    
+    // Format back to datetime-local format (YYYY-MM-DDTHH:mm)
+    const year2 = end.getFullYear()
+    const month2 = String(end.getMonth() + 1).padStart(2, '0') // month is 0-indexed
+    const day2 = String(end.getDate()).padStart(2, '0')
+    const hour2 = String(end.getHours()).padStart(2, '0')
+    const minute2 = String(end.getMinutes()).padStart(2, '0')
+    
+    const endTimeString = `${year2}-${month2}-${day2}T${hour2}:${minute2}`
+    console.log('End time string for input:', endTimeString)
+    
+    return endTimeString
+  }
+
+  // Handle success states and auto-refresh
+  useEffect(() => {
+    if (createState?.success) {
+      setCreateLoading(false)
+      setShowSuccess('create')
+      
+      // Clear the form
+      if (createFormRef) {
+        createFormRef.reset()
+      }
+      
+      // Reload the section by fetching fresh data
+      setTimeout(async () => {
+        setIsRefreshing(true)
+        try {
+          // Force page refresh to get updated contest data
+          window.location.reload()
+        } catch (error) {
+          console.error('Error refreshing:', error)
+          setIsRefreshing(false)
+        }
+      }, 1000)
+      
+      setTimeout(() => setShowSuccess(null), 3000)
+    }
+    if (createState?.error) {
+      setCreateLoading(false)
+    }
+  }, [createState, createFormRef])
+
+  useEffect(() => {
+    if (updateState?.success) {
+      setUpdateLoading(false)
+      setEditing(null)
+      setShowSuccess('update')
+      setTimeout(() => setShowSuccess(null), 3000)
+      // Refresh the page to get updated data
+      setTimeout(() => {
+        setIsRefreshing(true)
+        router.refresh()
+      }, 1500)
+    }
+    if (updateState?.error) {
+      setUpdateLoading(false)
+    }
+  }, [updateState, router])
+
+  const handleCreateSubmit = (e) => {
+    e.preventDefault()
+    setCreateLoading(true)
+    const formData = new FormData(e.currentTarget)
+    
+    // Calculate end time from start time and duration
+    const startTime = formData.get('start_time')
+    const duration = formData.get('duration_hours')
+    
+    if (startTime && duration) {
+      const endTime = calculateEndTime(startTime, parseFloat(duration))
+      formData.set('end_time', endTime)
+    }
+    
+    startTransition(async () => {
+      await createAction(formData)
+    })
+  }
+
+  const handleUpdateSubmit = (e) => {
+    e.preventDefault()
+    setUpdateLoading(true)
+    const formData = new FormData(e.currentTarget)
+    
+    // Calculate end time from start time and duration
+    const startTime = formData.get('start_time')
+    const duration = formData.get('duration_hours')
+    
+    if (startTime && duration) {
+      const endTime = calculateEndTime(startTime, parseFloat(duration))
+      formData.set('end_time', endTime)
+    }
+    
+    startTransition(async () => {
+      await updateAction(formData)
+    })
+  }
+
+  const getDurationFromTimes = (startTime, endTime) => {
+    console.log('Getting duration from times:')
+    console.log('Start time:', startTime)
+    console.log('End time:', endTime)
+    
+    // Parse dates as local time (same method as calculateEndTime)
+    const parseLocalDateTime = (dateTimeString) => {
+      const [datePart, timePart] = dateTimeString.split('T')
+      const [year, month, day] = datePart.split('-').map(Number)
+      const [hour, minute] = timePart.split(':').map(Number)
+      return new Date(year, month - 1, day, hour, minute) // month is 0-indexed
+    }
+    
+    const start = parseLocalDateTime(startTime)
+    const end = parseLocalDateTime(endTime)
+    
+    console.log('Parsed start (local):', start.toLocaleString())
+    console.log('Parsed end (local):', end.toLocaleString())
+    
+    const durationMs = end.getTime() - start.getTime()
+    const durationHours = durationMs / (1000 * 60 * 60)
+    
+    console.log('Duration in hours:', durationHours)
+    
+    return durationHours.toFixed(1) // Round to 1 decimal place
+  }
+
+  const handleRefresh = () => {
+    setIsRefreshing(true)
+    router.refresh()
+    setTimeout(() => setIsRefreshing(false), 1000)
+  }
+
+  // Update preview when start time or duration changes
+  const updateEndTimePreview = (startTime, duration) => {
+    if (startTime && duration) {
+      const endTime = calculateEndTime(startTime, parseFloat(duration))
+      setPreviewEndTime(endTime)
+    } else {
+      setPreviewEndTime('')
+    }
+  }
 
   return <div className='space-y-8'>
-    <form action={createAction} className='space-y-4 p-4 border rounded-lg'>
-      <h2 className='text-xl font-semibold'>Add Contest</h2>
-      <div className='grid md:grid-cols-2 gap-4'>
-        <div className='space-y-1'>
-          <label htmlFor='name' className='text-sm font-medium'>Name</label>
-          <Input id='name' name='name' placeholder='Name' required />
-        </div>
-        <div className='space-y-1'>
-          <label htmlFor='platform' className='text-sm font-medium'>Platform</label>
-          <Input id='platform' name='platform' placeholder='Platform (optional)' />
-        </div>
-        <div className='space-y-1 md:col-span-2'>
-          <label htmlFor='link' className='text-sm font-medium'>Link</label>
-          <Input id='link' name='link' placeholder='Link (optional)' />
-        </div>
-        <div className='space-y-1'>
-          <label htmlFor='start_time' className='text-sm font-medium'>Start Time</label>
-          <Input id='start_time' name='start_time' type='datetime-local' required />
-        </div>
-        <div className='space-y-1'>
-          <label htmlFor='end_time' className='text-sm font-medium'>End Time</label>
-          <Input id='end_time' name='end_time' type='datetime-local' required />
-        </div>
+    {/* Success notification */}
+    {showSuccess && (
+      <div className="fixed top-4 right-4 z-50 animate-in slide-in-from-top-2">
+        <Card className="border-green-200 bg-green-50 dark:bg-green-900/20">
+          <CardContent className="p-4 flex items-center gap-2">
+            <CheckCircle className="h-5 w-5 text-green-600" />
+            <span className="text-sm font-medium text-green-800 dark:text-green-200">
+              {showSuccess === 'create' ? 'Contest created successfully!' : 
+               showSuccess === 'update' ? 'Contest updated successfully!' : 
+               'Action completed successfully!'}
+            </span>
+          </CardContent>
+        </Card>
       </div>
-      <div className='space-y-1'>
-        <label htmlFor='description' className='text-sm font-medium'>Description</label>
-        <Textarea id='description' name='description' placeholder='Description (optional)' />
-      </div>
-      <Button type='submit'>Create</Button>
-      {createState?.error && <p className='text-sm text-red-500'>{createState.error}</p>}
-      {createState?.success && <p className='text-sm text-green-600'>Created</p>}
-    </form>
+    )}
 
-    <div className='space-y-4'>
-      <h2 className='text-xl font-semibold'>Existing Contests</h2>
+    {/* Refresh indicator */}
+    {isRefreshing && (
+      <div className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 animate-in slide-in-from-top-2">
+        <Card>
+          <CardContent className="p-3 flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
+            <span className="text-sm font-medium">Refreshing data...</span>
+          </CardContent>
+        </Card>
+      </div>
+    )}
+
+    {/* Add Contest Form */}
+    <Card className="border-2 border-dashed border-zinc-200 dark:border-zinc-800 hover:border-red-300 dark:hover:border-red-700 transition-colors">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Plus className="h-5 w-5 text-red-600" />
+          Add New Contest
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form ref={setCreateFormRef} onSubmit={handleCreateSubmit} className='space-y-4'>
+          <div className='grid md:grid-cols-2 gap-4'>
+            <div className='space-y-2'>
+              <label htmlFor='name' className='text-sm font-medium'>Contest Name</label>
+              <Input 
+                id='name' 
+                name='name' 
+                placeholder='Enter contest name' 
+                required 
+                disabled={createLoading}
+                className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+              />
+            </div>
+            <div className='space-y-2'>
+              <label htmlFor='platform' className='text-sm font-medium'>Platform</label>
+              <Input 
+                id='platform' 
+                name='platform' 
+                placeholder='e.g., Codeforces, CodeChef' 
+                disabled={createLoading}
+                className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+              />
+            </div>
+            <div className='space-y-2 md:col-span-2'>
+              <label htmlFor='link' className='text-sm font-medium'>Contest Link <span className="text-zinc-400 font-normal">(Optional)</span></label>
+              <Input 
+                id='link' 
+                name='link' 
+                placeholder='https://... (optional)' 
+                type="url"
+                disabled={createLoading}
+                className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+              />
+            </div>
+            <div className='space-y-2'>
+              <label htmlFor='start_time' className='text-sm font-medium'>Start Time</label>
+              <Input 
+                id='start_time' 
+                name='start_time' 
+                type='datetime-local' 
+                required 
+                disabled={createLoading}
+                className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                onChange={(e) => {
+                  const duration = document.getElementById('duration_hours')?.value
+                  updateEndTimePreview(e.target.value, duration)
+                }}
+              />
+            </div>
+            <div className='space-y-2'>
+              <label htmlFor='duration_hours' className='text-sm font-medium'>Duration (Hours)</label>
+              <Input 
+                id='duration_hours' 
+                name='duration_hours' 
+                type='number'
+                min='0.5'
+                step='0.5'
+                placeholder='e.g., 2, 3.5'
+                required 
+                disabled={createLoading}
+                className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                onChange={(e) => {
+                  const startTime = document.getElementById('start_time')?.value
+                  updateEndTimePreview(startTime, e.target.value)
+                }}
+              />
+              <div className="flex flex-col gap-1">
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">End time will be calculated automatically</p>
+                {previewEndTime && (
+                  <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">
+                    Preview end time: {(() => {
+                      const [datePart, timePart] = previewEndTime.split('T')
+                      const [year, month, day] = datePart.split('-').map(Number)
+                      const [hour, minute] = timePart.split(':').map(Number)
+                      const date = new Date(year, month - 1, day, hour, minute)
+                      return date.toLocaleString()
+                    })()}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className='space-y-2'>
+            <label htmlFor='description' className='text-sm font-medium'>Description</label>
+            <Textarea 
+              id='description' 
+              name='description' 
+              placeholder='Contest description (optional)' 
+              rows={3}
+              disabled={createLoading}
+              className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Button 
+              type='submit' 
+              disabled={createLoading}
+              className="bg-red-600 hover:bg-red-700 text-white min-w-[120px] transition-all duration-200"
+            >
+              {createLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                <>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create Contest
+                </>
+              )}
+            </Button>
+            
+            <Button 
+              type="button" 
+              variant="outline" 
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="min-w-[100px]"
+            >
+              {isRefreshing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Refreshing...
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Refresh
+                </>
+              )}
+            </Button>
+          </div>
+          
+          {createState?.error && (
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <p className='text-sm text-red-600 dark:text-red-400'>{createState.error}</p>
+            </div>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+
+    {/* Existing Contests */}
+    <div className='space-y-6'>
+      <div className="flex items-center justify-between">
+        <h2 className='text-2xl font-bold text-zinc-900 dark:text-zinc-100'>Existing Contests</h2>
+        <Badge variant="secondary" className="px-3 py-1">
+          {contests.length} contest{contests.length !== 1 ? 's' : ''}
+        </Badge>
+      </div>
+      
       <div className='space-y-4'>
-        {contests.map(c => <div key={c.id} className='border rounded-lg p-4'>
-          {editing === c.id ? <form action={updateAction} className='space-y-2'>
-            <input type='hidden' name='contest_id' value={c.id} />
-            <div className='grid md:grid-cols-2 gap-2'>
-              <div className='space-y-1'>
-                <label htmlFor={`name-${c.id}`} className='text-sm font-medium'>Name</label>
-                <Input id={`name-${c.id}`} name='name' defaultValue={c.name} required />
-              </div>
-              <div className='space-y-1'>
-                <label htmlFor={`platform-${c.id}`} className='text-sm font-medium'>Platform</label>
-                <Input id={`platform-${c.id}`} name='platform' defaultValue={c.platform||''} />
-              </div>
-              <div className='space-y-1 md:col-span-2'>
-                <label htmlFor={`link-${c.id}`} className='text-sm font-medium'>Link</label>
-                <Input id={`link-${c.id}`} name='link' defaultValue={c.link||''} />
-              </div>
-              <div className='space-y-1'>
-                <label htmlFor={`start-${c.id}`} className='text-sm font-medium'>Start Time</label>
-                <Input id={`start-${c.id}`} name='start_time' type='datetime-local' defaultValue={new Date(c.start_time).toISOString().slice(0,16)} required />
-              </div>
-              <div className='space-y-1'>
-                <label htmlFor={`end-${c.id}`} className='text-sm font-medium'>End Time</label>
-                <Input id={`end-${c.id}`} name='end_time' type='datetime-local' defaultValue={new Date(c.end_time).toISOString().slice(0,16)} required />
-              </div>
-            </div>
-            <div className='space-y-1'>
-              <label htmlFor={`desc-${c.id}`} className='text-sm font-medium'>Description</label>
-              <Textarea id={`desc-${c.id}`} name='description' defaultValue={c.description||''} />
-            </div>
-            <div className='flex gap-2'>
-              <Button type='submit' size='sm'>Save</Button>
-              <Button type='button' variant='outline' size='sm' onClick={()=>setEditing(null)}>Cancel</Button>
-            </div>
-            {updateState?.error && <p className='text-sm text-red-500'>{updateState.error}</p>}
-            {updateState?.success && <p className='text-sm text-green-600'>Updated</p>}
-          </form> : <>
-            <div className='flex flex-col md:flex-row md:items-center md:justify-between gap-2'>
-              <div>
-                <h3 className='font-medium'>{c.name}</h3>
-                <p className='text-xs text-muted-foreground'>{c.platform} • {new Date(c.start_time).toLocaleString()} - {new Date(c.end_time).toLocaleString()}</p>
-              </div>
-              <div className='flex gap-2'>
-                <Button size='sm' variant='outline' onClick={()=>setEditing(c.id)}>Edit</Button>
-                <form
-                  action={deleteAction}
-                  onSubmit={(e)=>{
-                    e.preventDefault()
-                    setEditing(null)
-                    const fd = new FormData(e.currentTarget)
-                    const id = c.id
-                    startTransition(async () => {
-                      const res = await deleteAction(fd)
-                      if(!res?.error){
-                        setContests(prev => prev.filter(x => x.id !== id))
-                        setDeletedIds(prev => new Set([...prev, id]))
-                      }
-                    })
-                  }}
-                >
+        {contests.map(c => (
+          <Card key={c.id} className="transition-all duration-200 hover:shadow-md border-zinc-200 dark:border-zinc-800">
+            {editing === c.id ? (
+              <CardContent className="p-6">
+                <form onSubmit={handleUpdateSubmit} className='space-y-4'>
                   <input type='hidden' name='contest_id' value={c.id} />
-                  <Button size='sm' variant='destructive'>Deactivate</Button>
+                  <div className='grid md:grid-cols-2 gap-4'>
+                    <div className='space-y-2'>
+                      <label htmlFor={`name-${c.id}`} className='text-sm font-medium'>Contest Name</label>
+                      <Input 
+                        id={`name-${c.id}`} 
+                        name='name' 
+                        defaultValue={c.name} 
+                        required 
+                        disabled={updateLoading}
+                        className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                      />
+                    </div>
+                    <div className='space-y-2'>
+                      <label htmlFor={`platform-${c.id}`} className='text-sm font-medium'>Platform</label>
+                      <Input 
+                        id={`platform-${c.id}`} 
+                        name='platform' 
+                        defaultValue={c.platform||''} 
+                        disabled={updateLoading}
+                        className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                      />
+                    </div>
+                    <div className='space-y-2 md:col-span-2'>
+                      <label htmlFor={`link-${c.id}`} className='text-sm font-medium'>Contest Link <span className="text-zinc-400 font-normal">(Optional)</span></label>
+                      <Input 
+                        id={`link-${c.id}`} 
+                        name='link' 
+                        defaultValue={c.link||''} 
+                        placeholder="https://... (optional)"
+                        type="url"
+                        disabled={updateLoading}
+                        className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                      />
+                    </div>
+                    <div className='space-y-2'>
+                      <label htmlFor={`start-${c.id}`} className='text-sm font-medium'>Start Time</label>
+                      <Input 
+                        id={`start-${c.id}`} 
+                        name='start_time' 
+                        type='datetime-local' 
+                        defaultValue={new Date(c.start_time).toISOString().slice(0,16)} 
+                        required 
+                        disabled={updateLoading}
+                        className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                      />
+                    </div>
+                    <div className='space-y-2'>
+                      <label htmlFor={`duration-${c.id}`} className='text-sm font-medium'>Duration (Hours)</label>
+                      <Input 
+                        id={`duration-${c.id}`} 
+                        name='duration_hours' 
+                        type='number'
+                        min='0.5'
+                        step='0.5'
+                        defaultValue={getDurationFromTimes(c.start_time, c.end_time)}
+                        required 
+                        disabled={updateLoading}
+                        className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                      />
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">End time will be calculated automatically</p>
+                    </div>
+                  </div>
+                  <div className='space-y-2'>
+                    <label htmlFor={`desc-${c.id}`} className='text-sm font-medium'>Description</label>
+                    <Textarea 
+                      id={`desc-${c.id}`} 
+                      name='description' 
+                      defaultValue={c.description||''} 
+                      rows={3}
+                      disabled={updateLoading}
+                      className="transition-all duration-200 focus:ring-2 focus:ring-red-500"
+                    />
+                  </div>
+                  <div className='flex gap-3'>
+                    <Button 
+                      type='submit' 
+                      disabled={updateLoading}
+                      className="bg-green-600 hover:bg-green-700 text-white min-w-[100px]"
+                    >
+                      {updateLoading ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        <>
+                          <Save className="mr-2 h-4 w-4" />
+                          Save
+                        </>
+                      )}
+                    </Button>
+                    <Button 
+                      type='button' 
+                      variant='outline' 
+                      onClick={()=>setEditing(null)}
+                      disabled={updateLoading}
+                    >
+                      <X className="mr-2 h-4 w-4" />
+                      Cancel
+                    </Button>
+                  </div>
+                  {updateState?.error && (
+                    <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                      <p className='text-sm text-red-600 dark:text-red-400'>{updateState.error}</p>
+                    </div>
+                  )}
                 </form>
+              </CardContent>
+            ) : (
+              <CardContent className="p-6">
+                <div className='flex flex-col md:flex-row md:items-center md:justify-between gap-4'>
+                  <div className="space-y-2 flex-1">
+                    <div className="flex items-center gap-3">
+                      <h3 className='font-bold text-lg text-zinc-900 dark:text-zinc-100'>{c.name}</h3>
+                      {c.platform && (
+                        <Badge variant="outline" className="text-xs">
+                          {c.platform}
+                        </Badge>
+                      )}
+                      <span className={`w-2 h-2 rounded-full ${
+                        Date.now() < new Date(c.start_time).getTime() ? 'bg-yellow-500' :
+                        Date.now() <= new Date(c.end_time).getTime() ? 'bg-green-500' : 'bg-red-500'
+                      }`}></span>
+                    </div>
+                    <p className='text-sm text-zinc-600 dark:text-zinc-400'>
+                      {new Date(c.start_time).toLocaleString()} - {new Date(c.end_time).toLocaleString()}
+                    </p>
+                    {c.description && (
+                      <p className='text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2'>{c.description}</p>
+                    )}
+                  </div>
+                  <div className='flex gap-2'>
+                    <Button 
+                      variant='outline' 
+                      onClick={()=>setEditing(c.id)}
+                      disabled={editing !== null || deleteLoading === c.id}
+                      className="transition-all duration-200 hover:bg-blue-50 hover:border-blue-300"
+                    >
+                      <Edit3 className="mr-2 h-4 w-4" />
+                      Edit
+                    </Button>
+                    <form
+                      onSubmit={(e)=>{
+                        e.preventDefault()
+                        setEditing(null)
+                        setDeleteLoading(c.id)
+                        const fd = new FormData(e.currentTarget)
+                        const id = c.id
+                        startTransition(async () => {
+                          const res = await deleteAction(fd)
+                          setDeleteLoading(null)
+                          if(!res?.error){
+                            setContests(prev => prev.filter(x => x.id !== id))
+                            setDeletedIds(prev => new Set([...prev, id]))
+                          }
+                        })
+                      }}
+                    >
+                      <input type='hidden' name='contest_id' value={c.id} />
+                      <Button 
+                        type="submit"
+                        variant='destructive' 
+                        disabled={editing !== null || deleteLoading === c.id}
+                        className="min-w-[110px] transition-all duration-200"
+                      >
+                        {deleteLoading === c.id ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Deleting...
+                          </>
+                        ) : (
+                          <>
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Deactivate
+                          </>
+                        )}
+                      </Button>
+                    </form>
+                  </div>
+                </div>
+                {deletedIds.has(c.id) && (
+                  <div className="mt-3 p-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+                    <p className='text-xs text-green-600 dark:text-green-400 flex items-center gap-2'>
+                      <CheckCircle className="h-4 w-4" />
+                      Contest deactivated successfully
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            )}        
+          </Card>
+        ))}
+        {contests.length === 0 && (
+          <Card className="border-dashed border-2">
+            <CardContent className="p-12 text-center">
+              <div className="space-y-3">
+                <div className="mx-auto w-12 h-12 bg-zinc-100 dark:bg-zinc-800 rounded-full flex items-center justify-center">
+                  <Plus className="h-6 w-6 text-zinc-400" />
+                </div>
+                <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-100">No contests yet</h3>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Get started by creating your first custom contest above.
+                </p>
               </div>
-            </div>
-            {deletedIds.has(c.id) && <p className='text-xs text-green-600'>Deactivated</p>}
-          </>}        
-        </div>)}
-        {contests.length === 0 && <p className='text-sm text-muted-foreground'>No contests yet.</p>}
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   </div>

--- a/client/src/components/custom-contest-display.jsx
+++ b/client/src/components/custom-contest-display.jsx
@@ -1,53 +1,257 @@
 "use client"
-import { useEffect, useState } from 'react'
-import { getActiveCustomContests } from '@/lib/action'
-import { Card, CardContent } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import CountdownTimer from '@/components/countdown-timer'
+import { PaginationControls } from '@/components/pagination-controls'
+import { SearchInput } from '@/components/search-input'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter } from '@/components/ui/card'
+import { getActiveCustomContests } from '@/lib/action'
+import { Clock, ExternalLink } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export default function CustomContestDisplay(){
   const [contests, setContests] = useState([])
+  const [filteredContests, setFilteredContests] = useState([])
   const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize, setPageSize] = useState(6)
+
   useEffect(()=>{
     (async ()=>{
       const data = await getActiveCustomContests()
+      console.log('Fetched contests:', data)
       setContests(data)
+      setFilteredContests(data)
       setLoading(false)
     })()
   },[])
-  if(loading) return <div className='flex justify-center'><div className='animate-spin h-8 w-8 rounded-full border-t-2 border-b-2 border-red-600'/></div>
-  if(contests.length === 0) return null
-  return <div className='space-y-4'>
-    {contests.map(c => <FeaturedContestCard key={c.id} contest={c} />)}
-  </div>
+
+  useEffect(() => {
+    let filtered = [...contests]
+    
+    if (searchQuery) {
+      filtered = filtered.filter(contest =>
+        contest.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (contest.platform && contest.platform.toLowerCase().includes(searchQuery.toLowerCase()))
+      )
+    }
+    
+    setFilteredContests(filtered)
+    setCurrentPage(1)
+  }, [searchQuery, contests])
+
+  const totalPages = Math.ceil(filteredContests.length / pageSize)
+
+  // Filter by status first, then apply pagination to each category
+  const upcomingContests = filteredContests.filter(contest => {
+    const now = Date.now()
+    const start = new Date(contest.start_time).getTime()
+    const isUpcoming = now < start
+    if (isUpcoming) {
+      console.log('Upcoming contest:', contest.name, 'Start:', new Date(contest.start_time), 'Now:', new Date(now))
+    }
+    return isUpcoming
+  })
+
+  const ongoingContests = filteredContests.filter(contest => {
+    const now = Date.now()
+    const start = new Date(contest.start_time).getTime()
+    const end = new Date(contest.end_time).getTime()
+    const isOngoing = now >= start && now <= end
+    if (isOngoing) {
+      console.log('Ongoing contest:', contest.name)
+    }
+    return isOngoing
+  })
+
+  const endedContests = filteredContests.filter(contest => {
+    const now = Date.now()
+    const end = new Date(contest.end_time).getTime()
+    const isEnded = now > end
+    if (isEnded) {
+      console.log('Ended contest:', contest.name)
+    }
+    return isEnded
+  })
+
+  console.log('Contest counts - Upcoming:', upcomingContests.length, 'Ongoing:', ongoingContests.length, 'Ended:', endedContests.length)
+
+  // Apply pagination to ended contests only (since upcoming and ongoing are typically fewer)
+  const totalEndedPages = Math.ceil(endedContests.length / pageSize)
+  const paginatedEndedContests = endedContests.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+
+  if(loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-red-600"></div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex justify-end">
+        <SearchInput
+          placeholder="Search MCC contests..."
+          value={searchQuery}
+          onChange={setSearchQuery}
+          className="w-full sm:w-64"
+        />
+      </div>
+
+      {upcomingContests.length > 0 && (
+        <div className="space-y-6">
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 border-l-4 border-red-600 pl-3">
+            Upcoming MCC Contests
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {upcomingContests.map(contest => <MCCContestCard key={contest.id} contest={contest} />)}
+          </div>
+        </div>
+      )}
+
+      {ongoingContests.length > 0 && (
+        <div className="space-y-6">
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 border-l-4 border-green-600 pl-3">
+            Ongoing MCC Contests
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {ongoingContests.map(contest => <MCCContestCard key={contest.id} contest={contest} />)}
+          </div>
+        </div>
+      )}
+
+      {endedContests.length > 0 && (
+        <div className="space-y-6">
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 border-l-4 border-zinc-400 pl-3">
+            Past MCC Contests
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {paginatedEndedContests.map(contest => <MCCContestCard key={contest.id} contest={contest} />)}
+          </div>
+        </div>
+      )}
+
+      {endedContests.length > pageSize && (
+        <PaginationControls
+          currentPage={currentPage}
+          totalPages={totalEndedPages}
+          pageSize={pageSize}
+          totalItems={endedContests.length}
+          onPageChange={setCurrentPage}
+          onPageSizeChange={setPageSize}
+        />
+      )}
+
+      {searchQuery && filteredContests.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-zinc-500 dark:text-zinc-400">No MCC contests found matching "{searchQuery}"</p>
+        </div>
+      )}
+
+      {!searchQuery && contests.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-zinc-500 dark:text-zinc-400">No MCC contests available at the moment</p>
+        </div>
+      )}
+    </div>
+  )
 }
 
-function FeaturedContestCard({ contest }){
+function MCCContestCard({ contest }) {
   const start = new Date(contest.start_time).getTime()
   const end = new Date(contest.end_time).getTime()
   const now = Date.now()
   const status = now < start ? 'UPCOMING' : (now <= end ? 'ONGOING' : 'ENDED')
+  
   const normalizeUrl = (url) => {
     if(!url) return '#'
     return /^(https?:)?\/\//i.test(url) ? (url.startsWith('http') ? url : `https:${url}`) : `https://${url}`
   }
-  return <Card className='border-2 border-red-500 shadow-md bg-gradient-to-r from-red-50 to-white dark:from-zinc-900 dark:to-zinc-900 relative overflow-hidden'>
-    <div className='absolute inset-0 pointer-events-none opacity-10 bg-[radial-gradient(circle_at_top_left,_var(--tw-gradient-stops))] from-red-400 via-transparent to-transparent' />
-    <CardContent className='p-6 flex flex-col md:flex-row md:items-center gap-6'>
-      <div className='flex-1 space-y-2'>
-        <div className='flex items-center gap-2'>
-          <span className='px-2 py-0.5 text-[10px] font-semibold rounded bg-red-600 text-white tracking-wide'>MCC</span>
-          {contest.platform && <span className='text-xs uppercase text-zinc-500 dark:text-zinc-400'>{contest.platform}</span>}
-          <span className={`text-xs font-semibold ${status==='UPCOMING'?'text-yellow-600': status==='ONGOING'? 'text-green-600':'text-zinc-500'}`}>{status}</span>
+
+  const formatDate = (timestamp) => {
+    return new Date(timestamp).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  const getDuration = () => {
+    const durationMs = end - start
+    const hours = Math.floor(durationMs / (1000 * 60 * 60))
+    return hours
+  }
+
+  return (
+    <Card className="overflow-hidden border-zinc-200 dark:border-zinc-800 hover:shadow-md transition-shadow">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex justify-between items-start">
+          <div className="space-y-1">
+            <div className="flex items-center space-x-2">
+              <span
+                className={`w-2 h-2 rounded-full ${
+                  status === 'UPCOMING' ? 'bg-yellow-500' : 
+                  status === 'ONGOING' ? 'bg-green-500' : 'bg-red-500'
+                }`}
+              ></span>
+              <span className="px-2 py-0.5 text-[10px] font-semibold rounded bg-red-600 text-white tracking-wide">
+                MCC
+              </span>
+              {contest.platform && (
+                <span className="text-xs uppercase text-zinc-500 dark:text-zinc-400">
+                  {contest.platform}
+                </span>
+              )}
+            </div>
+            <h3 className="font-bold text-lg text-zinc-900 dark:text-zinc-50 line-clamp-2">
+              {contest.name}
+            </h3>
+          </div>
         </div>
-        <h2 className='text-2xl font-bold tracking-tight'>{contest.name}</h2>
-        {contest.description && <p className='text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3'>{contest.description}</p>}
-        <p className='text-xs text-zinc-500 dark:text-zinc-500'>{new Date(contest.start_time).toLocaleString()} - {new Date(contest.end_time).toLocaleString()}</p>
-        {status==='UPCOMING' && <div><CountdownTimer targetTime={start} /></div>}
-      </div>
-      <div className='flex md:flex-col gap-3'>
-        {contest.link && <a href={normalizeUrl(contest.link)} target='_blank' rel='noopener noreferrer'><Button className='bg-red-600 hover:bg-red-700 text-white'>Visit</Button></a>}
-      </div>
-    </CardContent>
-  </Card>
+
+        <div className="space-y-2">
+          {contest.description && (
+            <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2">
+              {contest.description}
+            </p>
+          )}
+
+          <div className="flex items-center text-sm text-zinc-500 dark:text-zinc-400">
+            <Clock className="mr-2 h-4 w-4" />
+            <span>Duration: {getDuration()} {getDuration() === 1 ? 'hour' : 'hours'}</span>
+          </div>
+
+          <div className="flex items-center text-sm text-zinc-500 dark:text-zinc-400">
+            <span>
+              {status === 'ENDED' ? 'Ended on: ' : 'Starts on: '}
+              {formatDate(status === 'ENDED' ? contest.end_time : contest.start_time)}
+            </span>
+          </div>
+
+          {status === 'UPCOMING' && (
+            <div className="mt-4">
+              <CountdownTimer targetTime={start} />
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      <CardFooter className="p-0">
+        {contest.link && (
+          <a href={normalizeUrl(contest.link)} target="_blank" rel="noopener noreferrer" className="w-full">
+            <Button
+              variant="ghost"
+              className="w-full rounded-none h-12 text-red-600 hover:text-red-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 flex items-center justify-center gap-2"
+            >
+              {status === 'UPCOMING' ? 'Register' : status === 'ONGOING' ? 'Join Now' : 'View Results'}
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+          </a>
+        )}
+      </CardFooter>
+    </Card>
+  )
 }


### PR DESCRIPTION
This pull request introduces a major redesign and feature upgrade to the MCC contest display page. The changes focus on improving user experience by adding search and pagination, categorizing contests by status, and enhancing the visual presentation of contest cards. Additionally, new animation styles are added to the global CSS for smoother UI transitions.

**Contest display and filtering improvements:**

* Refactored `CustomContestDisplay` (now MCC contest display) to categorize contests into Upcoming, Ongoing, and Past, with each category displayed in its own section and Past contests paginated for easier browsing.
* Added a search input to filter contests by name or platform, with real-time updates and empty-state messages when no results are found.

**UI and visual enhancements:**

* Redesigned contest cards (`MCCContestCard`) to show status indicators, improved layout, contest duration, start/end times, and context-sensitive action buttons ("Register", "Join Now", "View Results").
* Updated tab navigation in `contest_reminders/page.js` to add MCC as the default tab, expand to three tabs (MCC, General, IUPC/ICPC), and reorganize contest content accordingly. [[1]](diffhunk://#diff-54e7a626e68b303cef2cd517ef03db297dcd06085d11be8e8e90db47f12fb315L1-R30) [[2]](diffhunk://#diff-54e7a626e68b303cef2cd517ef03db297dcd06085d11be8e8e90db47f12fb315R41-R44)

**Animation and styling:**

* Introduced new CSS keyframe animations (`slide-in-from-top`, `slide-out-to-top`, `fade-in`, `scale-in`) and utility classes (`animate-in`, `animate-out`, `animate-fade-in`, `animate-scale-in`) to enhance UI transitions and feedback.