### PR TITLE
fix: close mobile menu on navigation

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -208,43 +208,49 @@ const Navbar = async () => {
                       </SheetClose>
                     ))}
                   <hr className="my-4" />
-                  <ProgressLink
-                    href="/login"
-                    className={`${loggedIn && "hidden"}`}
-                  >
-                    <Button
-                      variant="outline"
-                      className="w-full justify-start text-lg"
+                  <SheetClose asChild>
+                    <ProgressLink
+                      href="/login"
+                      className={`${loggedIn && "hidden"}`}
                     >
-                      <LogIn className="mr-2 h-5 w-5" />
-                      Login
-                    </Button>
-                  </ProgressLink>
-                  <ProgressLink
-                    href="/signup"
-                    className={`${loggedIn && "hidden"}`}
-                  >
-                    <Button
-                      variant="default"
-                      className="w-full justify-start text-lg"
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start text-lg"
+                      >
+                        <LogIn className="mr-2 h-5 w-5" />
+                        Login
+                      </Button>
+                    </ProgressLink>
+                  </SheetClose>
+                  <SheetClose asChild>
+                    <ProgressLink
+                      href="/signup"
+                      className={`${loggedIn && "hidden"}`}
                     >
-                      <UserPlus className="mr-2 h-5 w-5" />
-                      Sign Up
-                    </Button>
-                  </ProgressLink>
-                  <ProgressLink
-                    href="/profile"
-                    className={`${!loggedIn && "hidden"}`}
-                  >
-                    <Avatar className="w-8 h-8">
-                      <AvatarImage
-                        src={user && user.result && user.result[0].profile_pic}
-                      />
-                      <AvatarFallback>
-                        {user && user.result && user.result[0].full_name[0]}
-                      </AvatarFallback>
-                    </Avatar>
-                  </ProgressLink>
+                      <Button
+                        variant="default"
+                        className="w-full justify-start text-lg"
+                      >
+                        <UserPlus className="mr-2 h-5 w-5" />
+                        Sign Up
+                      </Button>
+                    </ProgressLink>
+                  </SheetClose>
+                  <SheetClose asChild>
+                    <ProgressLink
+                      href="/profile"
+                      className={`${!loggedIn && "hidden"}`}
+                    >
+                      <Avatar className="w-8 h-8">
+                        <AvatarImage
+                          src={user && user.result && user.result[0].profile_pic}
+                        />
+                        <AvatarFallback>
+                          {user && user.result && user.result[0].full_name[0]}
+                        </AvatarFallback>
+                      </Avatar>
+                    </ProgressLink>
+                  </SheetClose>
                 </div>
               </SheetClose>
             </SheetContent>

--- a/client/src/components/ProgressLink.jsx
+++ b/client/src/components/ProgressLink.jsx
@@ -4,9 +4,12 @@ import Link from "next/link";
 import NProgress from "nprogress";
 import "nprogress/nprogress.css";
 import { usePathname } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 
-export default function ProgressLink({ href, children, className }) {
+const ProgressLink = forwardRef(function ProgressLink(
+  { href, children, className, onClick, ...props },
+  ref,
+) {
   const pathname = usePathname();
   const prevPath = useRef(pathname);
 
@@ -17,15 +20,25 @@ export default function ProgressLink({ href, children, className }) {
     }
   }, [pathname]);
 
-  const handleClick = () => {
-    if (pathname !== href) {
-      NProgress.start(); // start immediately on click
+  const handleClick = (event) => {
+    onClick?.(event);
+
+    if (!event.defaultPrevented && pathname !== href) {
+      NProgress.start();
     }
   };
 
   return (
-    <Link href={href} className={className} onClick={handleClick}>
+    <Link
+      ref={ref}
+      href={href}
+      className={className}
+      onClick={handleClick}
+      {...props}
+    >
       {children}
     </Link>
   );
-}
+});
+
+export default ProgressLink;


### PR DESCRIPTION
Forward ProgressLink refs and close the sheet around auth actions so mobile navigation dismisses reliably when users change pages.